### PR TITLE
Remove user generated content upon user deletion

### DIFF
--- a/app/Events/UserWasDeleted.php
+++ b/app/Events/UserWasDeleted.php
@@ -1,0 +1,23 @@
+<?php namespace App\Events;
+
+use App\Events\Event;
+
+use Illuminate\Queue\SerializesModels;
+
+class UserWasDeleted extends Event {
+
+	use SerializesModels;
+	
+	public $user_id;
+
+	/**
+	 * Create a new event instance.
+	 *
+	 * @return void
+	 */
+	public function __construct($user_id)
+	{
+		$this->user_id = $user_id;
+	}
+
+}

--- a/app/Handlers/Events/DeleteUserGeneratedContent.php
+++ b/app/Handlers/Events/DeleteUserGeneratedContent.php
@@ -1,0 +1,44 @@
+<?php namespace App\Handlers\Events;
+
+use App\Events\UserWasDeleted;
+
+use App\Article;
+use App\Photo;
+use App\PhotoAlbum;
+use App\Video;
+use App\VideoAlbum;
+
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldBeQueued;
+
+class DeleteUserGeneratedContent implements ShouldBeQueued {
+	
+	use InteractsWithQueue;
+
+	/**
+	 * Create the event handler.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		//
+	}
+
+	/**
+	 * Handle the event.
+	 *
+	 * @param  UserWasDeleted  $event
+	 * @return void
+	 */
+	public function handle(UserWasDeleted $event)
+	{
+		// Delete everything the user created
+		Article::where('user_id', $event->user_id)->delete();
+		Photo::where('user_id', $event->user_id)->delete();
+		PhotoAlbum::where('user_id', $event->user_id)->delete();
+		Video::where('user_id', $event->user_id)->delete();
+		VideoAlbum::where('user_id', $event->user_id)->delete();
+	}
+
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -1,5 +1,9 @@
 <?php namespace App\Providers;
 
+use App\Events\UserWasDeleted;
+use App\Handlers\Events\DeleteUserGeneratedContent;
+use App\User;
+
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
@@ -14,6 +18,9 @@ class EventServiceProvider extends ServiceProvider {
 		'event.name' => [
 			'EventListener',
 		],
+		UserWasDeleted::class => [
+			DeleteUserGeneratedContent::class,
+		],
 	];
 
 	/**
@@ -26,7 +33,10 @@ class EventServiceProvider extends ServiceProvider {
 	{
 		parent::boot($events);
 
-		//
+		User::deleting(function($user)
+		{
+			 \Event::fire(new UserWasDeleted($user->id));
+		});
 	}
 
 }


### PR DESCRIPTION
Right now, if a user has made articles/photos/etc and the user gets deleted then the *user_id* will be *NULL* for the article/photo/etc, and trying to load the homepage will throw out errors because it can't display an author value of *NULL*.

This is an event that gets fired when a user is deleted to search through the database for content made the user and deletes that content.