### PR TITLE
Explicitly set locale used by TestDummy/Faker - Update factory.php

### DIFF
--- a/tests/factories/factory.php
+++ b/tests/factories/factory.php
@@ -1,5 +1,6 @@
 <?php
 
+$faker->locale('en_US'); // set Locale of faked data - see https://github.com/fzaninotto/Faker/tree/master/src/Faker/Provider
 $faker->seed(1234); // manage image library
 
 $factory('App\User', [


### PR DESCRIPTION
Added $faker->locale('en_US'); to factory.php