### PR TITLE
Ensure required bower directory is available

### DIFF
--- a/resources/vendor/.gitignore
+++ b/resources/vendor/.gitignore
@@ -1,0 +1,2 @@
+# This directory is required by Bower.
+*


### PR DESCRIPTION
The following error is thrown if resources/vendor doesn't exist.

glob error { [Error: EPERM, readdir '/home/vagrant/Code/Laravel-5-Bootstrap-3-Starter-Site/resources/vendor']
  errno: 50,
  code: 'EPERM',
  path: '/home/vagrant/Code/Laravel-5-Bootstrap-3-Starter-Site/resources/vendor' }
[21:25:05] 'bower' errored after 3.16 s