### PR TITLE
add repositories field to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,13 @@
     "keywords": ["framework", "laravel"],
     "license": "MIT",
     "type": "project",
+    "repositories": [
+        {
+             "type": "composer", 
+             "url": "https://packagist.org"
+        },
+        { "packagist": false }
+    ],
     "require": {
         "php": ">=5.5.9",
         "laravel/framework": "5.1.*",


### PR DESCRIPTION
Without this in my **composer.json** I could not run `composer install`


```
$ composer install
Loading composer repositories with package information
The "https://packagist.org/packages.json" file could not be downloaded: php_network_getaddresses: getaddrinfo failed: nodename nor servname provided, or not known
failed to open stream: php_network_getaddresses: getaddrinfo failed: nodename nor servname provided, or not known
https://packagist.org could not be fully loaded, package information was loaded from the local cache and may be out of date
Installing dependencies (including require-dev)


                                                                                                  
  [Composer\Downloader\TransportException]                                                        
  The "http://packagist.org/p/yajra/laravel-datatables-oracle%24dda3e657697273ce5863f8c37563b6aa  
  86071324724205e1a58b97f3af7803ee.json" file could not be downloaded: php_network_getaddresses:  
   getaddrinfo failed: nodename nor servname provided, or not known                               
  failed to open stream: php_network_getaddresses: getaddrinfo failed: nodename nor servname pro  
  vided, or not known                                                                             
                                                                                                  


install [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-plugins] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--ignore-platform-reqs] [--] [<packages>]...
```

I found this soulution [here](https://laracasts.com/discuss/channels/general-discussion/composer-stopped-working-cant-figure-out). After adding this code `composer install` works peachy.